### PR TITLE
--delay s option sleeps for s seconds before forwarding

### DIFF
--- a/dumb-init.c
+++ b/dumb-init.c
@@ -54,6 +54,7 @@ int translate_signal(int signum) {
 void forward_signal(int signum) {
     signum = translate_signal(signum);
     if (signal_delay) {
+        DEBUG("Delaying signal %d for %d seconds.\n", signum, signal_delay);
         sleep(signal_delay);
     }
     if (signum != -1) {

--- a/dumb-init.c
+++ b/dumb-init.c
@@ -47,7 +47,12 @@ int translate_signal(int signum) {
         return signum;
     } else {
         int translated = signal_rewrite[signum];
-        return translated == -1 ? signum : translated;
+        if (translated == -1) {
+            return signum;
+        } else {
+            DEBUG("Translating signal %d to %d.\n", signum, translated);
+            return translated;
+        }
     }
 }
 


### PR DESCRIPTION
This is a terrible thing to do, and we shouldn't upstream this. We've
added a delay option to give registrator time to deregister our
containers before we signal the process to actually halt. Hopefully we
don't have to use this fork.
